### PR TITLE
Implementation of Neo4jIgnoreAttribute to control property serialization instead of JsonIgnoreAttribute

### DIFF
--- a/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
+++ b/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
@@ -3,6 +3,7 @@ using System;
 namespace Neo4jClient
 
 {
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public class Neo4jIgnoreAttribute : Attribute
     {
     }

--- a/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
+++ b/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Neo4jClient
+
+{
+    internal class Neo4jIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
+++ b/Neo4jClient.Shared/Attributes/Neo4jIgnoreAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Neo4jClient
 
 {
-    internal class Neo4jIgnoreAttribute : Attribute
+    public class Neo4jIgnoreAttribute : Attribute
     {
     }
 }

--- a/Neo4jClient.Shared/Cypher/VbComparer.cs
+++ b/Neo4jClient.Shared/Cypher/VbComparer.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq.Expressions;
-using Microsoft.VisualBasic.CompilerServices;
+﻿using Microsoft.VisualBasic.CompilerServices;
+using System.Linq.Expressions;
 
 namespace Neo4jClient.Cypher
 {

--- a/Neo4jClient.Shared/Cypher/VbComparer.cs
+++ b/Neo4jClient.Shared/Cypher/VbComparer.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.VisualBasic.CompilerServices;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
+using Microsoft.VisualBasic.CompilerServices;
 
 namespace Neo4jClient.Cypher
 {

--- a/Neo4jClient.Shared/GraphClient.cs
+++ b/Neo4jClient.Shared/GraphClient.cs
@@ -38,7 +38,7 @@ namespace Neo4jClient
             new EnumValueConverter()
         };
 
-        public static readonly DefaultContractResolver DefaultJsonContractResolver = new DefaultContractResolver();
+        public static readonly DefaultContractResolver DefaultJsonContractResolver = new Neo4jContractResolver();
 
         private ITransactionManager<HttpResponseMessage> transactionManager;
         private readonly IExecutionPolicyFactory policyFactory;

--- a/Neo4jClient.Shared/Neo4jClient.Shared.projitems
+++ b/Neo4jClient.Shared/Neo4jClient.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RelationshipTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RootApiResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Attributes\Neo4jDateTimeAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Attributes\Neo4jIgnoreAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CypherPartialResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\All.cs" />
@@ -196,6 +197,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\EnumValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\ICypherJsonDeserializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\ISerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\Neo4jContractResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\NullableEnumValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\PartialDeserializationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TimeZoneInfoConverter.cs" />

--- a/Neo4jClient.Shared/Neo4jDriverExtensions.cs
+++ b/Neo4jClient.Shared/Neo4jDriverExtensions.cs
@@ -83,7 +83,7 @@ namespace Neo4jClient
         private static object SerializeObject(Type type, object value, IList<JsonConverter> converters, IGraphClient gc)
         {
             return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Where(pi => !(pi.GetIndexParameters().Any() || pi.IsDefined(typeof(JsonIgnoreAttribute))))
+                .Where(pi => !(pi.GetIndexParameters().Any() || pi.IsDefined(typeof(JsonIgnoreAttribute)) || pi.IsDefined(typeof(Neo4jIgnoreAttribute))))
                 .ToDictionary(pi => pi.Name, pi => Serialize(pi.GetValue(value), converters, gc, pi.CustomAttributes));
         }
         

--- a/Neo4jClient.Shared/Serialization/Neo4jContractResolver.cs
+++ b/Neo4jClient.Shared/Serialization/Neo4jContractResolver.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Neo4jClient.Serialization
+{
+    public class Neo4jContractResolver : DefaultContractResolver
+    {
+        private readonly Dictionary<Type, HashSet<string>> _ignores;
+        private readonly Dictionary<Type, Dictionary<string, string>> _renames;
+
+        public Neo4jContractResolver()
+        {
+            _ignores = new Dictionary<Type, HashSet<string>>();
+            _renames = new Dictionary<Type, Dictionary<string, string>>();
+        }
+
+        public void IgnoreProperty(Type type, params string[] jsonPropertyNames)
+        {
+            if (!_ignores.ContainsKey(type))
+                _ignores[type] = new HashSet<string>();
+
+            foreach (var prop in jsonPropertyNames)
+                _ignores[type].Add(prop);
+        }
+
+        public void RenameProperty(Type type, string propertyName, string newJsonPropertyName)
+        {
+            if (!_renames.ContainsKey(type))
+                _renames[type] = new Dictionary<string, string>();
+
+            _renames[type][propertyName] = newJsonPropertyName;
+        }
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+
+            PropertyInfo prop = property.DeclaringType.GetProperty(property.PropertyName);
+            if (prop != null && prop.CustomAttributes.Any(a => a.AttributeType == typeof(Neo4jIgnoreAttribute)))
+            {
+                property.ShouldSerialize = i => false;
+            }
+
+            if (IsRenamed(property.DeclaringType, property.PropertyName, out var newJsonPropertyName))
+                property.PropertyName = newJsonPropertyName;
+
+            return property;
+        }
+
+        private bool IsIgnored(Type type, string jsonPropertyName)
+        {
+            if (!_ignores.ContainsKey(type))
+                return false;
+
+            return _ignores[type].Contains(jsonPropertyName);
+        }
+
+        private bool IsRenamed(Type type, string jsonPropertyName, out string newJsonPropertyName)
+        {
+            Dictionary<string, string> renames;
+
+            if (!_renames.TryGetValue(type, out renames) || !renames.TryGetValue(jsonPropertyName, out newJsonPropertyName))
+            {
+                newJsonPropertyName = null;
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Neo4jClient.Shared/Serialization/Neo4jContractResolver.cs
+++ b/Neo4jClient.Shared/Serialization/Neo4jContractResolver.cs
@@ -9,30 +9,11 @@ namespace Neo4jClient.Serialization
 {
     public class Neo4jContractResolver : DefaultContractResolver
     {
-        private readonly Dictionary<Type, HashSet<string>> _ignores;
         private readonly Dictionary<Type, Dictionary<string, string>> _renames;
 
         public Neo4jContractResolver()
         {
-            _ignores = new Dictionary<Type, HashSet<string>>();
             _renames = new Dictionary<Type, Dictionary<string, string>>();
-        }
-
-        public void IgnoreProperty(Type type, params string[] jsonPropertyNames)
-        {
-            if (!_ignores.ContainsKey(type))
-                _ignores[type] = new HashSet<string>();
-
-            foreach (var prop in jsonPropertyNames)
-                _ignores[type].Add(prop);
-        }
-
-        public void RenameProperty(Type type, string propertyName, string newJsonPropertyName)
-        {
-            if (!_renames.ContainsKey(type))
-                _renames[type] = new Dictionary<string, string>();
-
-            _renames[type][propertyName] = newJsonPropertyName;
         }
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
@@ -49,14 +30,6 @@ namespace Neo4jClient.Serialization
                 property.PropertyName = newJsonPropertyName;
 
             return property;
-        }
-
-        private bool IsIgnored(Type type, string jsonPropertyName)
-        {
-            if (!_ignores.ContainsKey(type))
-                return false;
-
-            return _ignores[type].Contains(jsonPropertyName);
         }
 
         private bool IsRenamed(Type type, string jsonPropertyName, out string newJsonPropertyName)

--- a/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
+++ b/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
@@ -240,11 +240,12 @@ namespace Neo4jClient.Test.Serialization
             public string Text { get; set; }
             [Neo4jIgnore]
             public string TextIgnore { get; set; }
-            public int TestInt { get; set; }
+            [JsonProperty("TestInt")]
+            public int TestIntRenamed { get; set; }
             [Neo4jIgnore]
-            public int TestNeo4jIntgnore { get; set; }
+            public int TestNeo4jIntIgnore { get; set; }
             [JsonIgnore]
-            public int TestJsonIntgnore { get; set; }
+            public int TestJsonIntIgnore { get; set; }
         }
 
         [Fact]
@@ -252,7 +253,7 @@ namespace Neo4jClient.Test.Serialization
         public void JsonSerializerShouldNotSerializeNeo4JIgnoreAttribute()
         {
             // Arrange
-            var testNode = new TestNodeWithSomeNeo4JIgnoreAttributes() { Text = "foo", TextIgnore = "fooignore", TestInt = 42, TestNeo4jIntgnore = 42, TestJsonIntgnore = 42 };
+            var testNode = new TestNodeWithSomeNeo4JIgnoreAttributes() { Text = "foo", TextIgnore = "fooignore", TestIntRenamed = 42, TestNeo4jIntIgnore = 42, TestJsonIntIgnore = 42 };
             var serializer = new CustomJsonSerializer
             {
                 NullHandling = NullValueHandling.Ignore,

--- a/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
+++ b/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
@@ -234,5 +234,40 @@ namespace Neo4jClient.Test.Serialization
             Assert.NotNull(model.MyPoint);
             Assert.Equal(new System.Drawing.Point(100, 200), model.MyPoint);
         }
+
+        public class TestNodeWithSomeNeo4JIgnoreAttributes
+        {
+            public string Text { get; set; }
+            [Neo4jIgnore]
+            public string TextIgnore { get; set; }
+            public int TestInt { get; set; }
+            [Neo4jIgnore]
+            public int TestNeo4jIntgnore { get; set; }
+            [JsonIgnore]
+            public int TestJsonIntgnore { get; set; }
+        }
+
+        [Fact]
+        //[Description("test https part of https://github.com/Readify/Neo4jClient/issues/336  https://github.com/Readify/Neo4jClient/pull/337  - see BoltGraphClientTests for bolt part")]
+        public void JsonSerializerShouldNotSerializeNeo4JIgnoreAttribute()
+        {
+            // Arrange
+            var testNode = new TestNodeWithSomeNeo4JIgnoreAttributes() { Text = "foo", TextIgnore = "fooignore", TestInt = 42, TestNeo4jIntgnore = 42, TestJsonIntgnore = 42 };
+            var serializer = new CustomJsonSerializer
+            {
+                NullHandling = NullValueHandling.Ignore,
+                JsonConverters = GraphClient.DefaultJsonConverters
+            };
+
+            // Act
+            var result = serializer.Serialize(testNode);
+
+            const string expectedValue = "{\r\n  \"Text\": \"foo\",\r\n  \"TestInt\": 42\r\n}";
+
+            // Assert
+            Assert.Equal(expectedValue, result);
+        }
+
+
     }
 }

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -69,6 +69,11 @@
     <Compile Include="NameValueCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic">
+      <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\Microsoft.VisualBasic.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <Import Project="..\Neo4jClient.Shared\Neo4jClient.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Neo4jClient/project.json
+++ b/Neo4jClient/project.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "Microsoft.DependencyValidation.Analyzers": "0.9.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-    "Microsoft.VisualBasic": "10.2.0",
     "Neo4j.Driver.Signed": "1.7.0",
     "NETStandard.Library": "2.0.0",
     "Newtonsoft.Json": "9.0.1",
@@ -12,7 +11,7 @@
     "System.ComponentModel": "4.3.0",
     "System.ComponentModel.Annotations": "4.4.0",
     "System.ComponentModel.TypeConverter": "4.3.0",
-    "System.Reflection.TypeExtensions": "4.4.0",
+    "System.Reflection.TypeExtensions": "4.5.1",
     "System.Runtime.Serialization.Primitives": "4.3.0"
   },
   "frameworks": {


### PR DESCRIPTION
Implementation of Neo4jIgnoreAttribute as BoltGraphClient serializes object parameters ignoring JsonContractResolver, see #336 
Works with BoltGraphClient and GraphClient 