### PR TITLE
Fix #381 - JsonConverters check CanRead/CanWrite before branching

### DIFF
--- a/Neo4jClient.Tests/Extensions/Neo4jDriverExtensionsTests.cs
+++ b/Neo4jClient.Tests/Extensions/Neo4jDriverExtensionsTests.cs
@@ -319,6 +319,7 @@ namespace Neo4jClient.Tests.Extensions
                 var actual = query.Query.ToNeo4jDriverParameters(mockGc.Object);
                 actual.Keys.Should().Contain("value");
                 // Upon regression, actual["value"] will be of type JObject
+                actual["value"].Should().NotBeOfType<JObject>();
                 actual["value"].Should().BeOfType<Dictionary<string, object>>();
                 var serializedObj = (Dictionary<string, object>)actual["value"];
 

--- a/Neo4jClient.Tests/Extensions/Neo4jDriverExtensionsTests.cs
+++ b/Neo4jClient.Tests/Extensions/Neo4jDriverExtensionsTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Moq;
 using Neo4jClient.Cypher;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Neo4jClient.Tests.Extensions
@@ -28,6 +29,27 @@ namespace Neo4jClient.Tests.Extensions
     internal class ClassWithDateTimeOffset
     {
         public DateTimeOffset Dt { get; set; }
+    }
+
+    internal class ClassWithString
+    {
+        public string String { get; set; }
+    }
+
+    internal class ClassWithStringReadOnlyConverter : JsonConverter<ClassWithString>
+    {
+        public override bool CanRead => true;
+        public override ClassWithString ReadJson(JsonReader reader, Type objectType, ClassWithString existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var jo = JObject.Load(reader);
+            return jo.ToObject<ClassWithString>();
+        }
+
+        public override bool CanWrite => false;
+        public override void WriteJson(JsonWriter writer, ClassWithString value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class Neo4jDriverExtensionsTests
@@ -274,6 +296,33 @@ namespace Neo4jClient.Tests.Extensions
                 var serializedObj = (Dictionary<string, object>) actual["p"];
 
                 serializedObj["Dt"].Should().Be(dateTime.ToUniversalTime().Ticks);
+            }
+
+            [Fact]
+            // Issue 381 - https://github.com/DotNet4Neo4j/Neo4jClient/issues/381
+            public void UsesCustomJsonSerializersAndRespectsReadOnly()
+            {
+                var obj = new ClassWithString
+                {
+                    String = "This is a String"
+                };
+
+                var mockGc = MockGc;
+                mockGc
+                    .Setup(x => x.JsonConverters)
+                    .Returns(new List<JsonConverter> { new ClassWithStringReadOnlyConverter() });
+
+                var query = new CypherFluentQuery(mockGc.Object)
+                    .Create("(n:Node $value)")
+                    .WithParam("value", obj);
+
+                var actual = query.Query.ToNeo4jDriverParameters(mockGc.Object);
+                actual.Keys.Should().Contain("value");
+                // Upon regression, actual["value"] will be of type JObject
+                actual["value"].Should().BeOfType<Dictionary<string, object>>();
+                var serializedObj = (Dictionary<string, object>)actual["value"];
+
+                serializedObj["String"].Should().Be(obj.String);
             }
         }
     }

--- a/Neo4jClient/Cypher/CypherReturnExpressionBuilder.cs
+++ b/Neo4jClient/Cypher/CypherReturnExpressionBuilder.cs
@@ -524,7 +524,7 @@ namespace Neo4jClient.Cypher
                 return true;
 
             jsonConvertersThatTheDeserializerWillUse = jsonConvertersThatTheDeserializerWillUse ?? GraphClient.DefaultJsonConverters;
-            if (jsonConvertersThatTheDeserializerWillUse.Any(c => c.CanConvert(type)))
+            if (jsonConvertersThatTheDeserializerWillUse.Any(c => c.CanConvert(type) && c.CanRead))
                 return true;
 
             var hasDefaultConstructor = type.GetConstructor(Type.EmptyTypes) != null;

--- a/Neo4jClient/Neo4jDriverExtensions.cs
+++ b/Neo4jClient/Neo4jDriverExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -67,7 +67,7 @@ namespace Neo4jClient
             var type = value.GetType();
             var typeInfo = type.GetTypeInfo();
 
-            var converter = converters.FirstOrDefault(c => c.CanConvert(type));
+            var converter = converters.FirstOrDefault(c => c.CanConvert(type) && c.CanWrite);
             if (converter != null)
             {
                 var serializer = new CustomJsonSerializer{JsonConverters = converters, JsonContractResolver = ((IRawGraphClient)gc).JsonContractResolver};

--- a/Neo4jClient/Serialization/CommonDeserializerMethods.cs
+++ b/Neo4jClient/Serialization/CommonDeserializerMethods.cs
@@ -310,7 +310,7 @@ namespace Neo4jClient.Serialization
         static bool TryJsonConverters(DeserializationContext context, Type type, JToken element, out object instance)
         {
             instance = null;
-            var converter = context.JsonConverters?.FirstOrDefault(c => c.CanConvert(type));
+            var converter = context.JsonConverters?.FirstOrDefault(c => c.CanConvert(type) && c.CanRead);
             if (converter == null) return false;
             using (var reader = element.CreateReader())
             {

--- a/Neo4jClient/Serialization/CustomJsonSerializer.cs
+++ b/Neo4jClient/Serialization/CustomJsonSerializer.cs
@@ -37,7 +37,7 @@ namespace Neo4jClient.Serialization
 
             if (JsonConverters != null)
             {
-                foreach (var converter in JsonConverters.Reverse())
+                foreach (var converter in JsonConverters.Reverse().Where(writer => writer.CanWrite))
                     serializer.Converters.Add(converter);
             }
 
@@ -62,7 +62,7 @@ namespace Neo4jClient.Serialization
 
             if (JsonConverters != null)
             {
-                foreach (var converter in JsonConverters.Reverse())
+                foreach (var converter in JsonConverters.Reverse().Where(writer => writer.CanRead))
                     serializer.Converters.Add(converter);
             }
 

--- a/Neo4jClient/StatementResultHelper.cs
+++ b/Neo4jClient/StatementResultHelper.cs
@@ -284,7 +284,7 @@ namespace Neo4jClient
             };
 
             foreach (var jsonConverter in converters)
-                if (jsonConverter.CanConvert(typeof(T)))
+                if (jsonConverter.CanConvert(typeof(T)) && jsonConverter.CanRead)
                     return JsonConvert.DeserializeObject<T>(record[identifier].As<INode>().ToJsonString(), serializerSettings);
 
 


### PR DESCRIPTION
Searched for all calls to `JsonConverter.CanConvert(Type)` and added the correct check to `JsonConverter.CanRead` or `JsonConverter.CanWrite`