### PR TITLE
Add the ability to `CALL` other queries

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryCallTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryCallTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using Neo4jClient.Cypher;
 using NSubstitute;
 using Xunit;
@@ -8,6 +11,11 @@ namespace Neo4jClient.Tests.Cypher
     
     public class CypherFluentQueryCallTests : IClassFixture<CultureInfoSetupFixture>
     {
+        private class Foo
+        {
+            public int Id { get; set; }
+        }
+
         private static IRawGraphClient GraphClient_30
         {
             get
@@ -44,5 +52,165 @@ namespace Neo4jClient.Tests.Cypher
 
             Assert.Throws<InvalidOperationException>(() => new CypherFluentQuery(client).Call("apoc.sp").Query);
         }
+
+        [Fact]
+        public void Call_SubQueriesAsLambda()
+        {
+            const string expected = @"CALL { MATCH (n)
+RETURN count(n) AS c }
+RETURN c";
+
+            var client = GraphClient_30;
+            
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Call(() => query)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Call_SubQueriesAsLambdaWithParameters()
+        {
+            const string expected = @"CALL { MATCH (n)
+WHERE (n.Id = $p0)
+RETURN count(n) AS c }
+RETURN c";
+
+            var client = GraphClient_30;
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Where((Foo n) => n.Id == 1)
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Call(() => query)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+            callQuery.Query.QueryParameters.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void Call_SubQueriesAsLambdaWithParametersPriorToCall()
+        {
+            const string expected = @"MATCH (x)
+WHERE (x.Id = $p0)
+CALL { MATCH (n)
+WHERE (n.Id = $p1)
+RETURN count(n) AS c }
+RETURN c";
+
+            var client = GraphClient_30;
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Where((Foo n) => n.Id == 1)
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Match("(x)")
+                .Where((Foo x) => x.Id == 2)
+                .Call(() => query)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+            callQuery.Query.QueryParameters.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Call_SubQueriesAsLambdaWithParametersAfterToCall()
+        {
+            const string expected = @"CALL { MATCH (n)
+WHERE (n.Id = $p0)
+RETURN count(n) AS c }
+MATCH (x)
+WHERE (x.Id = $p1)
+RETURN c";
+
+            var client = GraphClient_30;
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Where((Foo n) => n.Id == 1)
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Call(() => query)
+                .Match($"(x)")
+                .Where((Foo x) => x.Id == 2)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+            callQuery.Query.QueryParameters.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Call_SubQueriesAsLambdaWithParametersPriorToCall_WholeWord()
+        {
+            const string expected = @"MATCH (x)
+WHERE (x.Id = $p0)
+CALL { MATCH (n)
+WHERE (n.Id = $p1)
+AND (n.Something = $p2)
+RETURN count(n) AS c }
+RETURN c";
+
+            var client = GraphClient_30;
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Where("(n.Id = $p0)")
+                .AndWhere("(n.Something = $p1)")
+                .WithParam("p0", 1)
+                .WithParam("p1", 2)
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Match("(x)")
+                .Where("(x.Id = $p0)")
+                .WithParam("p0", 3)
+                .Call(() => query)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+            callQuery.Query.QueryParameters.Should().HaveCount(3);
+            callQuery.Query.QueryParameters.Should().ContainKeys("p0", "p1", "p2");
+        }
+
+        [Fact]
+        public void Call_SubQueriesAsLambdaWithParametersPriorAndAfterToCall_WholeWord()
+        {
+            const string expected = @"MATCH (x)
+WHERE (x.Id = $p0)
+CALL { MATCH (n)
+WHERE (n.Id = $p1)
+AND (n.Something = $p2)
+RETURN count(n) AS c }
+WHERE (y.Id = $p3)
+RETURN c";
+
+            var client = GraphClient_30;
+            var query = new CypherFluentQuery(client)
+                .Match("(n)")
+                .Where("(n.Id = $p0)")
+                .AndWhere("(n.Something = $p1)")
+                .WithParam("p0", 1)
+                .WithParam("p1", 2)
+                .Return(n => new {c = n.Count()});
+            
+            var callQuery = new CypherFluentQuery(client)
+                .Match("(x)")
+                .Where((IdClass x) => x.Id == 1)
+                .Call(() => query)
+                .Where((IdClass y) => y.Id == 1)
+                .Return(c => c.As<long>());
+
+            callQuery.Query.QueryText.Should().Be(expected);
+            callQuery.Query.QueryParameters.Should().HaveCount(4);
+            callQuery.Query.QueryParameters.Should().ContainKeys("p0", "p1", "p2", "p3");
+        }
+        private class IdClass {public int Id { get;set; }}
     }
 }

--- a/Neo4jClient/Cypher/CypherFluentQuery`Where.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Where.cs
@@ -14,19 +14,18 @@ namespace Neo4jClient.Cypher
         internal ICypherFluentQuery AndWhere(LambdaExpression expression)
         {
             return Mutate(w =>
-                w.AppendClause(string.Format("AND {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties))));
+                w.AppendClause($"AND {CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties)}"));
         }
 
         internal ICypherFluentQuery OrWhere(LambdaExpression expression)
         {
             return Mutate(w =>
-                w.AppendClause(string.Format("OR {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties))));
+                w.AppendClause($"OR {CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties)}"));
         }
 
         public ICypherFluentQuery Where(string text)
         {
-            return Mutate(w =>
-                w.AppendClause(string.Format("WHERE {0}", text)));
+            return Mutate(w => w.AppendClause($"WHERE {text}"));
         }
 
         public ICypherFluentQuery Where<T1>(Expression<Func<T1, bool>> expression)

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -68,6 +68,16 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery Call(string storedProcedureText);
 
         /// <summary>
+        /// [Neo4j 4.0+] Calls a SubQuery on the Database.
+        /// </summary>
+        /// <remarks>This only works on Neo4j 4.0+</remarks>
+        /// <param name="storedProcedureText">The Sub Query to execute.</param>
+        /// <returns>An <see cref="ICypherFluentQuery"/> instance to continue the query with.</returns>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="storedProcedureText"/> argument is empty or null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to call this against a server version prior to 3.0.</exception>
+        ICypherFluentQuery Call<T>(Func<ICypherFluentQuery<T>> subQuery);
+
+        /// <summary>
         /// [Neo4j 3.0+] Yields the values from the response of a <see cref="Call"/> method
         /// </summary>
         /// <remarks>This only works on Neo4j 3.0+</remarks>


### PR DESCRIPTION
So you can now do:

```
MATCH (x)
CALL { MATCH (y) RETURN COUNT(y) AS c }
RETURN x,c
```

But using functions, so, you can do:

```
var query = new CypherFluentQuery(client)
    .Match("(n)")
    .Return(n => new {c = n.Count()});

var callQuery = new CypherFluentQuery(client)
    .Call(() => query)
    .Return(c => c.As<long>());
```