### PR TITLE
Http and Bolt clients serialize input parameters differently

### DIFF
--- a/Neo4jClient.Tests/TestUtilities.cs
+++ b/Neo4jClient.Tests/TestUtilities.cs
@@ -21,10 +21,10 @@ namespace Neo4jClient.Tests
 
                 var v1 = d1[d1Key];
                 var v2 = d2[d1Key];
-                if (v1.GetType() == typeof(Dictionary<TKey, TValue>))
+                if (v1?.GetType() == typeof(Dictionary<TKey, TValue>))
                     return IsEqualTo((IDictionary<TKey, TValue>)v1, (IDictionary<TKey, TValue>)v2);
 
-                if (!d1[d1Key].Equals(d2[d1Key]))
+                if(!Equals(d1[d1Key], d2[d1Key]))
                     return false;
             }
             return true;

--- a/Neo4jClient/BoltGraphClient.cs
+++ b/Neo4jClient/BoltGraphClient.cs
@@ -70,7 +70,7 @@ namespace Neo4jClient
         /// <param name="username">The username to connect to Neo4j with.</param>
         /// <param name="password">The password to connect to Neo4j with.</param>
         /// <param name="realm">The realm to connect to Neo4j with.</param>
-        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null)
+        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
         {
             var localUris = uris?.ToList();
             if (localUris != null && localUris.Any())
@@ -104,30 +104,31 @@ namespace Neo4jClient
                 JsonConverters = JsonConverters,
                 Username = username,
                 Password = password,
-                Realm = realm
+                Realm = realm,
+                SerializeNullValues = serializeNullValues.GetValueOrDefault()
             };
 
             transactionManager = new BoltTransactionManager(this);
         }
 
-        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null)
-            : this(uri, null, username, password, realm, encryptionLevel)
+        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+            : this(uri, null, username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
-        public BoltGraphClient(IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null)
-            : this(new Uri("neo4j://virtual.neo4j.uri"), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel)
+        public BoltGraphClient(IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+            : this(new Uri("neo4j://virtual.neo4j.uri"), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
-        public BoltGraphClient(string uri, IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null)
-        : this(new Uri(uri), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel)
+        public BoltGraphClient(string uri, IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        : this(new Uri(uri), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel, serializeNullValues)
         {}
 
-        public BoltGraphClient(string uri, string username = null, string password= null, string realm = null, EncryptionLevel? encryptionLevel = null)
-            : this(new Uri(uri), username, password, realm, encryptionLevel)
+        public BoltGraphClient(string uri, string username = null, string password= null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+            : this(new Uri(uri), username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
         public BoltGraphClient(IDriver driver)
-            : this(new Uri("neo4j://Neo4j-Driver-Does-Not-Supply-This/"), null, null, null, null)
+            : this(new Uri("neo4j://Neo4j-Driver-Does-Not-Supply-This/"), null, null, null, null, null)
         {
             Driver = driver;
         }

--- a/Neo4jClient/BoltGraphClient.cs
+++ b/Neo4jClient/BoltGraphClient.cs
@@ -70,7 +70,7 @@ namespace Neo4jClient
         /// <param name="username">The username to connect to Neo4j with.</param>
         /// <param name="password">The password to connect to Neo4j with.</param>
         /// <param name="realm">The realm to connect to Neo4j with.</param>
-        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool serializeNullValues = false)
         {
             var localUris = uris?.ToList();
             if (localUris != null && localUris.Any())
@@ -105,30 +105,30 @@ namespace Neo4jClient
                 Username = username,
                 Password = password,
                 Realm = realm,
-                SerializeNullValues = serializeNullValues.GetValueOrDefault()
+                SerializeNullValues = serializeNullValues
             };
 
             transactionManager = new BoltTransactionManager(this);
         }
 
-        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool serializeNullValues = false)
             : this(uri, null, username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
-        public BoltGraphClient(IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        public BoltGraphClient(IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool serializeNullValues = false)
             : this(new Uri("neo4j://virtual.neo4j.uri"), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
-        public BoltGraphClient(string uri, IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        public BoltGraphClient(string uri, IEnumerable<string> uris, string username = null, string password = null, string realm = null, EncryptionLevel? encryptionLevel = null, bool serializeNullValues = false)
         : this(new Uri(uri), uris?.Select(UriCreator.From).ToList(), username, password, realm, encryptionLevel, serializeNullValues)
         {}
 
-        public BoltGraphClient(string uri, string username = null, string password= null, string realm = null, EncryptionLevel? encryptionLevel = null, bool? serializeNullValues = null)
+        public BoltGraphClient(string uri, string username = null, string password= null, string realm = null, EncryptionLevel? encryptionLevel = null, bool serializeNullValues = false)
             : this(new Uri(uri), username, password, realm, encryptionLevel, serializeNullValues)
         { }
 
         public BoltGraphClient(IDriver driver)
-            : this(new Uri("neo4j://Neo4j-Driver-Does-Not-Supply-This/"), null, null, null, null, null)
+            : this(new Uri("neo4j://Neo4j-Driver-Does-Not-Supply-This/"), null, null, null, null, false)
         {
             Driver = driver;
         }

--- a/Neo4jClient/Execution/ExecutionConfiguration.cs
+++ b/Neo4jClient/Execution/ExecutionConfiguration.cs
@@ -22,5 +22,6 @@ namespace Neo4jClient.Execution
         public Guid ResourceManagerId { get; set; }
         public string Realm { get; set; }
         public EncryptionLevel? EncryptionLevel { get; set; }
+        public bool SerializeNullValues { get; set; }
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/DotNet4Neo4j/Neo4jClient/issues/419 issue

* Introduce property `SerializeNullValues` in `ExecutionConfiguration` class
* Pass new `serializeNullValues` parameter to constructors
* Modify `Neo4jDriverExtensions` to either preserve or skip null values of Objects and Dictionaries depending on congifuration
* Introduce new tests to verify new logic
* Additionally one fix for the `TestUtilities` class to compare dictionaries when left side or right side value is null

