### PR TITLE
Added improved neo exception handling and error message

### DIFF
--- a/Neo4jClient.Tests/Serialization/CypherJsonDeserializerTests.cs
+++ b/Neo4jClient.Tests/Serialization/CypherJsonDeserializerTests.cs
@@ -1537,5 +1537,22 @@ namespace Neo4jClient.Tests.Serialization
             // Assert
             Assert.Equal(new byte[] { 1, 2, 3, 4 }, result);
         }
+
+        [Fact]
+        public void DeserializerShouldThrowNeoExceptionForSyntaxError()
+        {
+            // Arrange 
+            var client = Substitute.For<IGraphClient>();
+            var deserializer = new CypherJsonDeserializer<byte[]>(client, CypherResultMode.Set, CypherResultFormat.DependsOnEnvironment);
+            var content = @"{
+                          'results': [],
+                          'errors': [ { 
+                            'code': 'Neo.ClientError.Statement.SyntaxError', 
+                            'message': 'Parentheses are required to identify nodes in patterns, i.e. (user) (line 1, column 7 (offset: 6))\r\n\'MATCH user:User\'\r\n       ^'}]
+                          }".Replace("'", "\"");
+
+            // Act & Assert
+            Assert.Throws<NeoException>(() => deserializer.Deserialize(content, true).First());
+        }
     }
 }

--- a/Neo4jClient/Serialization/CommonDeserializerMethods.cs
+++ b/Neo4jClient/Serialization/CommonDeserializerMethods.cs
@@ -31,8 +31,8 @@ namespace Neo4jClient.Serialization
         public static NeoException DeserializeNeo4jError(JToken error) =>
             new NeoException(new ApiModels.ExceptionResponse
             {
-                Exception = error.First.Value<JToken>("code").ToString(),
-                Message = error.First.Value<JToken>("message").ToString(),
+                Exception = error.First?.Value<JToken>("code")?.ToString(),
+                Message = error.First?.Value<JToken>("message")?.ToString(),
             });
 
         public static string ReplaceAllDateInstancesWithNeoDates(string content)

--- a/Neo4jClient/Serialization/CommonDeserializerMethods.cs
+++ b/Neo4jClient/Serialization/CommonDeserializerMethods.cs
@@ -19,9 +19,21 @@ namespace Neo4jClient.Serialization
         public static string RemoveResultsFromJson(string content)
         {
             var root = JToken.Parse(content);
+            var errors = root.Value<JToken>("errors");
+            if (errors != null && errors.HasValues)
+            {
+                throw DeserializeNeo4jError(errors);
+            }
             var output = root.SelectTokens("$.results[0]").Select(j => j.ToString(Formatting.None)).FirstOrDefault();
             return output;
         }
+
+        public static NeoException DeserializeNeo4jError(JToken error) =>
+            new NeoException(new ApiModels.ExceptionResponse
+            {
+                Exception = error.First.Value<JToken>("code").ToString(),
+                Message = error.First.Value<JToken>("message").ToString(),
+            });
 
         public static string ReplaceAllDateInstancesWithNeoDates(string content)
         {


### PR DESCRIPTION
This PR is related to the following StackOverflow post: https://stackoverflow.com/questions/69697645/neo4jclient-was-unable-to-deserialize-into-the-object-structure-you-supplied-p

A Neo4j syntax error was not throwing a neo exception meaning the error message did not help debug the problem (missing parenthesis). I've added a deserializer method to catch any neo errors and throw a neo exception so users can easily debug.