### PR TITLE
StatementResultHelper.ToString should use JsonSettings when serializing objects

### DIFF
--- a/Neo4jClient.Tests/StatementResultHelperTests.cs
+++ b/Neo4jClient.Tests/StatementResultHelperTests.cs
@@ -679,6 +679,11 @@ namespace Neo4jClient.Tests
 
         public class ToJsonStringMethod : IClassFixture<CultureInfoSetupFixture>
         {
+            public ToJsonStringMethod()
+            {
+                StatementResultHelper.JsonSettings.ContractResolver = null;
+            }
+
             private class Foo
             {
                 public string BarStr { get; set; }
@@ -757,6 +762,37 @@ namespace Neo4jClient.Tests
                 result.Replace(" ", "").Should().Be("{\"Foo\":\"foo\",\"Bar\":1}");
             }
 
+            [Fact]
+            public void Poco_DeserializedCorrectlyUsingDifferentContractResolver()
+            {
+                StatementResultHelper.JsonSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                
+                var poco = new Poco {Foo = "some-foo", Bar = 123};
+                var result = poco.ToJsonString(false, false, false);
+
+                result.Replace(" ", "").Should().Be("{\"foo\":\"some-foo\",\"bar\":123}");
+            }
+
+            [Fact]
+            public void NestedPoco_DeserializedCorrectly()
+            {
+                var poco = new Poco {Foo = "foo", Bar = 1};
+                var result = poco.ToJsonString(false, true, false);
+
+                result.Replace(" ", "").Should().Be("{\"Foo\":\"foo\",\"Bar\":1}");
+            }
+
+            [Fact]
+            public void NestedPoco_DeserializedCorrectlyUsingDifferentContractResolver()
+            {
+                StatementResultHelper.JsonSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                
+                var poco = new Poco {Foo = "some-foo", Bar = 123};
+                var result = poco.ToJsonString(false, true, false);
+
+                result.Replace(" ", "").Should().Be("{\"foo\":\"some-foo\",\"bar\":123}");
+            }            
+            
             [Fact]
             public void ListPocoNotNested()
             {

--- a/Neo4jClient/StatementResultHelper.cs
+++ b/Neo4jClient/StatementResultHelper.cs
@@ -129,7 +129,7 @@ namespace Neo4jClient
                     return $"[{string.Join(",", output)}]";
                 }
 
-                return JsonConvert.SerializeObject(o);
+                return JsonConvert.SerializeObject(o, JsonSettings);
             }
 
             if (o is IDictionary || oType == typeof(IDictionary<string, object>) || oType == typeof(Dictionary<string, object>))
@@ -182,7 +182,7 @@ namespace Neo4jClient
                     return $"[{{{string.Join(",", output)}}}]";
                 return $"[{string.Join(",", output)}]";
             }
-            return JsonConvert.SerializeObject(o);
+            return JsonConvert.SerializeObject(o, JsonSettings);
         }
 
         private static string GetColumns(IEnumerable<string> keys)


### PR DESCRIPTION
This PR is to fix issue #431:
- Modified StatementResultHelper.ToString to pass JsonSettings to JsonConvert.SerializeObject (so it uses the configured JsonContractResolver)