### PR TITLE
Fixed serialization/deserialization of PathsResultBoltRelationship and PathsResultBoltNode

### DIFF
--- a/Neo4jClient/ApiModels/Cypher/PathsResultBolt.cs
+++ b/Neo4jClient/ApiModels/Cypher/PathsResultBolt.cs
@@ -39,13 +39,18 @@ namespace Neo4jClient.ApiModels.Cypher
 
         public class PathsResultBoltRelationship
         {
+            [JsonProperty("Id")]
             public long Id { get; set; }
+            [JsonProperty("Type")]
             public string Type { get; set; }
+            [JsonProperty("StartNodeId")]
             public long StartNodeId { get; set; }
+            [JsonProperty("EndNodeId")]
             public long EndNodeId { get; set; }
 
             public object this[string key] => Properties[key];
 
+            [JsonProperty("Properties")]
             public Dictionary<string, object> Properties { get; set; }
 
             public PathsResultBoltRelationship() { Properties = new Dictionary<string, object>(); }
@@ -90,9 +95,12 @@ namespace Neo4jClient.ApiModels.Cypher
 
         public class PathsResultBoltNode 
         {
+            [JsonProperty("Id")]
             public long Id { get; set; }
+            [JsonProperty("Labels")]
             public List<string> Labels { get; set; }
             public object this[string key] => Properties[key];
+            [JsonProperty("Properties")]
             public Dictionary<string, object> Properties { get; set; }
 
             public PathsResultBoltNode() { Properties = new Dictionary<string, object>(); }


### PR DESCRIPTION
This PR is to fix issue #431:
- decorated properties of PathsResultBoltRelationship and PathsResultBoltNode with JsonProperty to ensure correct serialization/deserialization when using CamelCasePropertyNamesContractResolver