### PR TITLE
Issue 436 DebugQueryText should serialize object property names without quotes

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
@@ -137,6 +137,5 @@ namespace Neo4jClient.Tests.Cypher
             const string expected = "MATCH null";
             Assert.Equal(expected, query.DebugQueryText);
         }
-
     }
 }

--- a/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
@@ -10,6 +10,31 @@ namespace Neo4jClient.Tests.Cypher
     
     public class CypherQueryTests : IClassFixture<CultureInfoSetupFixture>
     {
+        [Fact]
+        //Issue 436: https://github.com/DotNet4Neo4j/Neo4jClient/issues/436
+        public void DebugQueryTextShouldSerializeObjectPropertyNamesWithoutQuotes()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var dummyObject = new { key = "value" };
+
+            var query = new CypherFluentQuery(client)
+                .Merge("(foo:Foo $object)")
+                .WithParam("object", dummyObject)
+                .Query;
+
+            string expected = "MERGE (foo:Foo {" + Environment.NewLine + "  key: \"value\"" + Environment.NewLine + "})";
+            Assert.Equal(expected, query.DebugQueryText);
+
+            var dummyString = "value";
+
+            query = new CypherFluentQuery(client)
+                .Merge("(foo:Foo { key: $value })")
+                .WithParam("value", dummyString)
+                .Query;
+
+            expected = "MERGE (foo:Foo { key: \"value\" })";
+            Assert.Equal(expected, query.DebugQueryText);
+        }
 
         [Fact]
         //Issue 349: https://github.com/DotNet4Neo4j/Neo4jClient/issues/349
@@ -112,5 +137,6 @@ namespace Neo4jClient.Tests.Cypher
             const string expected = "MATCH null";
             Assert.Equal(expected, query.DebugQueryText);
         }
+
     }
 }

--- a/Neo4jClient/Cypher/CypherQuery.cs
+++ b/Neo4jClient/Cypher/CypherQuery.cs
@@ -103,12 +103,12 @@ namespace Neo4jClient.Cypher
                 }
 
                 var serializer = BuildSerializer();
+                serializer.QuoteName = false;
 
                 var text = queryText;
                 foreach (var key in queryParameters.Keys)
                 {
                     var value = queryParameters[key];
-                    serializer.QuoteName = false;
                     value = serializer.Serialize(value);  
                     text = Regex.Replace(text, $"\\$\\b{key}\\b", value.ToString());
                 }

--- a/Neo4jClient/Cypher/CypherQuery.cs
+++ b/Neo4jClient/Cypher/CypherQuery.cs
@@ -108,6 +108,7 @@ namespace Neo4jClient.Cypher
                 foreach (var key in queryParameters.Keys)
                 {
                     var value = queryParameters[key];
+                    serializer.QuoteName = false;
                     value = serializer.Serialize(value);  
                     text = Regex.Replace(text, $"\\$\\b{key}\\b", value.ToString());
                 }


### PR DESCRIPTION
see [https://github.com/DotNet4Neo4j/Neo4jClient/issues/436](url)