### PR TITLE
Support Neo4j Native datetime Types for Serialization Through Client Setting

### DIFF
--- a/Neo4jClient.Tests/BoltGraphClientTests/BoltGraphClientTests.cs
+++ b/Neo4jClient.Tests/BoltGraphClientTests/BoltGraphClientTests.cs
@@ -43,11 +43,15 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         }
         public class ServerInfo : TestStatementResult
         {
-            public ServerInfo(): base(new List<IRecord> {new TestRecord(new Dictionary<string, object>
+            public ServerInfo(Version version) : base(new List<IRecord> {new TestRecord(new Dictionary<string, object>
             {
                 {"name", "neo4j kernel"},
-                {"versions", new List<object>{"3.2.3"} }
+                {"versions", new List<object>{version.ToString(3)} }
             })})
+            {
+            }
+
+            public ServerInfo() : this(new Version(3, 4, 0))
             {
             }
 

--- a/Neo4jClient.Tests/BoltGraphClientTests/BoltGraphClientTests.cs
+++ b/Neo4jClient.Tests/BoltGraphClientTests/BoltGraphClientTests.cs
@@ -73,7 +73,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task SerializerShouldTakeIntoAccountTheContractResolverProvided()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -97,7 +97,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task JsonSerializerShouldNotSerializeNeo4jIgnoreAttribute()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -123,7 +123,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task SerializesDateTimesProperly()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
             
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -150,7 +150,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task SerializesDateTimeOffsetsProperly()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -177,7 +177,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task SerializesGuidsProperly()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -202,7 +202,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         public async Task SerializesGuidsProperlyWhenAutoGeneratingParams()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -268,7 +268,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
         private static async Task SerializesObjectProperlyWitDifferentStrategies(IDictionary<string, object> expectedParameters, Action<BoltGraphClient> setupClient)
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()"))
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null))
                 .Returns(Task.FromResult<IResultCursor>(new ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();

--- a/Neo4jClient.Tests/BoltGraphClientTests/ConnectAsyncTests.cs
+++ b/Neo4jClient.Tests/BoltGraphClientTests/ConnectAsyncTests.cs
@@ -20,7 +20,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
             var testSr = new TestStatementResult(new[] {recordMock.Object});
             var sessionMock = new Mock<IAsyncSession>();
             sessionMock
-                .Setup(s => s.RunAsync("CALL dbms.components()"))
+                .Setup(s => s.RunAsync("CALL dbms.components()", null))
                 .Returns(Task.FromResult<IResultCursor>(testSr));
 
             var driverMock = new Mock<IDriver>();
@@ -82,6 +82,9 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
 
         public IReadOnlyList<string> Keys { get; }
         public IRecord Current => records[pos];
+
+        /// <inheritdoc />
+        public bool IsOpen { get; set; }
     }
 
     
@@ -103,7 +106,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests
             var testSr = new TestStatementResult(new[] {record1Mock.Object, record2Mock.Object});
             var sessionMock = new Mock<IAsyncSession>();
             sessionMock
-                .Setup(s => s.RunAsync("CALL dbms.components()"))
+                .Setup(s => s.RunAsync("CALL dbms.components()", null))
                 .Returns(Task.FromResult<IResultCursor>(testSr));
 
             var driverMock = new Mock<IDriver>();

--- a/Neo4jClient.Tests/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
+++ b/Neo4jClient.Tests/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
@@ -62,6 +62,9 @@ namespace Neo4jClient.Tests.BoltGraphClientTests.Cypher
         public string Type { get; set; }
         public long StartNodeId { get; set; }
         public long EndNodeId { get; set; }
+        public string ElementId { get; set; }
+        public string StartNodeElementId { get; set; }
+        public string EndNodeElementId { get; set; }
 
         #endregion
     }
@@ -91,6 +94,7 @@ namespace Neo4jClient.Tests.BoltGraphClientTests.Cypher
         #region Implementation of INode
 
         public IReadOnlyList<string> Labels { get; set; }
+        public string ElementId { get; set; }
 
         #endregion
     }

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
+++ b/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Neo4jClient.Tests.Serialization
@@ -14,6 +15,13 @@ namespace Neo4jClient.Tests.Serialization
         {
             [Neo4jDateTime]
             public DateTime Dt { get; set; }
+        }
+
+        private class ClassWithoutNeo4jDateTime
+        {
+            public DateTime Dt1 { get; set; }
+
+            public DateTimeOffset Dt2 { get; set; }
         }
 
         [Fact]
@@ -45,6 +53,80 @@ namespace Neo4jClient.Tests.Serialization
             var query = cfq.Query;
             var parameters = query.ToNeo4jDriverParameters(bgc);
             parameters.IsEqualTo(expectedParameters).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CannotUseNativeGlobalSettingWithOlderVersions()
+        {
+            var mockSession = new Mock<IAsyncSession>();
+
+            // native datetime types were introduced in 3.4
+            var oldVersion = new Version(3, 0, 0);
+
+            // for ConnectAsync()
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo(oldVersion)));
+
+            var mockDriver = new Mock<IDriver>();
+            mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
+
+            var bgc = new BoltGraphClient(mockDriver.Object, useDriverDateTypes: true);
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await bgc.ConnectAsync());
+        }
+
+
+        [Fact]
+        public async Task SerializesDateTimeAsNeoDateWithGlobalSetting()
+        {
+            var mockSession = new Mock<IAsyncSession>();
+            // for ConnectAsync()
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
+            
+            var dt1 = new DateTime(2000, 1, 1, 0, 0, 0);
+            var dt2 = new DateTimeOffset(dt1);
+
+            var mockDriver = new Mock<IDriver>();
+            mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
+
+
+            var bgc = new BoltGraphClient(mockDriver.Object, useDriverDateTypes: true);
+            await bgc.ConnectAsync();
+
+            var cwd = new ClassWithoutNeo4jDateTime { Dt1 = dt1, Dt2 = dt2 }; ;
+
+            var cfq = bgc.Cypher.Create("(c)").WithParam("testParam", cwd);
+
+            var expectedParameters = new Dictionary<string, object>
+            {
+                {
+                    "testParam", new Dictionary<string, object> {{"Dt1", dt1}, {"Dt2", dt2}}
+                }
+            };
+
+            var query = cfq.Query;
+            var parameters = query.ToNeo4jDriverParameters(bgc);
+            parameters.IsEqualTo(expectedParameters).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task SerializesDateTimeGeneratedParametersAsNeoDateWithGlobalSetting()
+        {
+            var mockSession = new Mock<IAsyncSession>();
+            // for ConnectAsync()
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
+
+            var mockDriver = new Mock<IDriver>();
+            mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
+
+
+            var bgc = new BoltGraphClient(mockDriver.Object, useDriverDateTypes: true);
+            await bgc.ConnectAsync();
+
+            var comparedDt = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+            var cfq = bgc.Cypher.Match("(c)").Where<ClassWithoutNeo4jDateTime>(c => c.Dt2 >= comparedDt);
+            var query = cfq.Query;
+            var parameters = query.ToNeo4jDriverParameters(bgc);
+            parameters.Should().HaveCount(1).And.ContainValue(comparedDt);
         }
 
     }

--- a/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
+++ b/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver;
-using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Neo4jClient.Tests.Serialization
@@ -64,7 +63,7 @@ namespace Neo4jClient.Tests.Serialization
             var oldVersion = new Version(3, 0, 0);
 
             // for ConnectAsync()
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo(oldVersion)));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo(oldVersion)));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);
@@ -79,7 +78,7 @@ namespace Neo4jClient.Tests.Serialization
         {
             var mockSession = new Mock<IAsyncSession>();
             // for ConnectAsync()
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
             
             var dt1 = new DateTime(2000, 1, 1, 0, 0, 0);
             var dt2 = new DateTimeOffset(dt1);
@@ -112,7 +111,7 @@ namespace Neo4jClient.Tests.Serialization
         {
             var mockSession = new Mock<IAsyncSession>();
             // for ConnectAsync()
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
 
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.AsyncSession(It.IsAny<Action<SessionConfigBuilder>>())).Returns(mockSession.Object);

--- a/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
+++ b/Neo4jClient.Tests/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
@@ -20,7 +20,7 @@ namespace Neo4jClient.Tests.Serialization
         public async Task SerializesDateTimeAsNeoDateInBolt()
         {
             var mockSession = new Mock<IAsyncSession>();
-            mockSession.Setup(s => s.RunAsync("CALL dbms.components()")).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
+            mockSession.Setup(s => s.RunAsync("CALL dbms.components()", null)).Returns(Task.FromResult<IResultCursor>(new BoltGraphClientTests.BoltGraphClientTests.ServerInfo()));
             var dt = new DateTime(2000, 1, 1, 0, 0, 0);
 
             var mockDriver = new Mock<IDriver>();

--- a/Neo4jClient.Tests/StatementResultHelperTests.cs
+++ b/Neo4jClient.Tests/StatementResultHelperTests.cs
@@ -35,23 +35,42 @@ namespace Neo4jClient.Tests
             public TestRelationship(IDictionary<string, object> properties, int id = 99, int startId = 100, int endId = 200)
             {
                 StartNodeId = startId;
+                StartNodeElementId = startId.ToString();
                 EndNodeId = endId;
+                EndNodeElementId = endId.ToString();
                 Properties = new ReadOnlyDictionary<string, object>(properties);
                 Id = id;
+                ElementId = id.ToString();
             }
 
             public object this[string key] => Properties[key];
 
             public IReadOnlyDictionary<string, object> Properties { get; }
+            
+            [Obsolete ("Long versions of the ID will be removed in the future, use ElementId instead")]
             public long Id { get; }
+
+            /// <inheritdoc />
+            public string ElementId { get; }
+
             public bool Equals(IRelationship other)
             {
                 return true;
             }
 
             public string Type { get; }
+
+            [Obsolete ("Long versions of the ID will be removed in the future, use StartNodeElementId instead")]
             public long StartNodeId { get; }
+
+            [Obsolete ("Long versions of the ID will be removed in the future, use EndNodeElementId instead")]
             public long EndNodeId { get; }
+
+            /// <inheritdoc />
+            public string StartNodeElementId { get;  }
+
+            /// <inheritdoc />
+            public string EndNodeElementId { get;  }
         }
 
         private class TestNode : INode
@@ -61,13 +80,20 @@ namespace Neo4jClient.Tests
             {
                 Properties = properties;
                 Id = id;
+                ElementId = id.ToString();
                 Labels = new List<string> { "Foo" };
             }
 
             public object this[string key] => Properties[key];
 
             public IReadOnlyDictionary<string, object> Properties { get; }
+            
+            /// <inheritdoc />
+            [Obsolete ("Long versions of the ID will be removed in the future, use ElementId instead")]
             public long Id { get; }
+
+            /// <inheritdoc />
+            public string ElementId { get; set; }
 
             public bool Equals(INode other)
             {

--- a/Neo4jClient/DriverWrapper.cs
+++ b/Neo4jClient/DriverWrapper.cs
@@ -45,42 +45,42 @@ namespace Neo4jClient
             }
         }
 
-        public IAsyncSession Session()
-        {
-            return driver.AsyncSession();
-        }
-
-        public IAsyncSession Session(AccessMode defaultMode)
-        {
-            return driver.AsyncSession(x => x.WithDefaultAccessMode(defaultMode));
-        }
-
-        public IAsyncSession Session(string bookmark)
-        {
-            return driver.AsyncSession(x => x.WithBookmarks(Bookmark.From(bookmark)));
-        }
-
-        public IAsyncSession Session(AccessMode defaultMode, string bookmark)
-        {
-            return driver.AsyncSession(x => x.WithDefaultAccessMode(defaultMode).WithBookmarks(Bookmark.From(bookmark)));
-        }
-
-        public IAsyncSession Session(AccessMode defaultMode, IEnumerable<string> bookmarks)
-        {
-            return driver.AsyncSession(x =>
-            {
-                x.WithDefaultAccessMode(defaultMode);
-                if (bookmarks != null) x.WithBookmarks(Bookmark.From(bookmarks.ToArray()));
-            });
-        }
-
-        public IAsyncSession Session(IEnumerable<string> bookmarks)
-        {
-            return driver.AsyncSession(x =>
-            {
-                if (bookmarks != null) x.WithBookmarks(Bookmark.From(bookmarks.ToArray()));
-            });
-        }
+        // public IAsyncSession Session()
+        // {
+        //     return driver.AsyncSession();
+        // }
+        //
+        // public IAsyncSession Session(AccessMode defaultMode)
+        // {
+        //     return driver.AsyncSession(x => x.WithDefaultAccessMode(defaultMode));
+        // }
+        //
+        // public IAsyncSession Session(string bookmark)
+        // {
+        //     return driver.AsyncSession(x => x.WithBookmarks(Bookmark.From(bookmark)));
+        // }
+        //
+        // public IAsyncSession Session(AccessMode defaultMode, string bookmark)
+        // {
+        //     return driver.AsyncSession(x => x.WithDefaultAccessMode(defaultMode).WithBookmarks(Bookmark.From(bookmark)));
+        // }
+        //
+        // public IAsyncSession Session(AccessMode defaultMode, IEnumerable<string> bookmarks)
+        // {
+        //     return driver.AsyncSession(x =>
+        //     {
+        //         x.WithDefaultAccessMode(defaultMode);
+        //         if (bookmarks != null) x.WithBookmarks(Bookmark.From(bookmarks.ToArray()));
+        //     });
+        // }
+        //
+        // public IAsyncSession Session(IEnumerable<string> bookmarks)
+        // {
+        //     return driver.AsyncSession(x =>
+        //     {
+        //         if (bookmarks != null) x.WithBookmarks(Bookmark.From(bookmarks.ToArray()));
+        //     });
+        // }
         
         public IAsyncSession AsyncSession()
         {
@@ -97,6 +97,12 @@ namespace Neo4jClient
             return driver.CloseAsync();
         }
 
+        /// <inheritdoc />
+        public Task<IServerInfo> GetServerInfoAsync()
+        {
+            return driver.GetServerInfoAsync();
+        }
+
         public Task VerifyConnectivityAsync()
         {
             return driver.VerifyConnectivityAsync();
@@ -108,6 +114,9 @@ namespace Neo4jClient
         }
 
         public Config Config => driver.Config;
+
+        /// <inheritdoc />
+        public bool Encrypted => driver.Encrypted;
 
         public Uri Uri { get; private set; }
 

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -53,6 +53,11 @@ namespace Neo4jClient
 
         public bool UseJsonStreamingIfAvailable { get; set; }
 
+        public GraphClient(string rootUri, string username = null, string password = null)
+            : this(new Uri(rootUri), new HttpClientWrapper(username, password))
+        {
+        }
+
         public GraphClient(Uri rootUri, string username = null, string password = null)
             : this(rootUri, new HttpClientWrapper(username, password))
         {

--- a/Neo4jClient/IBoltGraphClient.cs
+++ b/Neo4jClient/IBoltGraphClient.cs
@@ -21,5 +21,10 @@ namespace Neo4jClient
         bool IsConnected { get; }
 
         Task ConnectAsync(NeoServerConfiguration configuration = null);
+
+        /// <summary>
+        /// Indicates if client should use the native driver date time types, instead of serialized datetime strings.
+        /// </summary>
+        bool UseDriverDateTypes { get; }
     }
 }

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -22,7 +22,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
       <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-      <PackageReference Include="Neo4j.Driver.Signed" Version="4.4.0" />
+      <PackageReference Include="Neo4j.Driver.Signed" Version="5.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
       <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />

--- a/Neo4jClient/Neo4jDriverExtensions.cs
+++ b/Neo4jClient/Neo4jDriverExtensions.cs
@@ -78,6 +78,13 @@ namespace Neo4jClient
                 var serializer = new CustomJsonSerializer{JsonConverters = converters, JsonContractResolver = ((IRawGraphClient)gc).JsonContractResolver};
                 return JsonConvert.DeserializeObject<CustomJsonConverterHelper>(serializer.Serialize(new {value})).Value;
             }
+            
+            // check if it is a date time object and the bolt driver has native date time objects enabled
+            if (((gc as IBoltGraphClient)?.UseDriverDateTypes ?? false) && CanHandleNativeDateTimeType(type))
+            {
+                // the driver will take care of serialization
+                return value;
+            }
 
             if (customAttributes != null && customAttributes.Any(x => x.AttributeType == typeof(Neo4jDateTimeAttribute)))
             {
@@ -100,6 +107,11 @@ namespace Neo4jClient
             }
 
             return SerializePrimitive(type, typeInfo, value);
+        }
+
+        private static bool CanHandleNativeDateTimeType(Type type)
+        {
+            return type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan);
         }
         
         private static object SerializeObject(Type type, object value, IList<JsonConverter> converters, IGraphClient gc)

--- a/Neo4jClient/Neo4jDriverExtensions.cs
+++ b/Neo4jClient/Neo4jDriverExtensions.cs
@@ -29,6 +29,11 @@ namespace Neo4jClient
             return transaction.RunAsync(query.QueryText, query.ToNeo4jDriverParameters(gc));
         }
 
+        public static Task<IResultCursor> RunAsync(this IAsyncQueryRunner queryRunner, CypherQuery query, IGraphClient gc)
+        {
+            return queryRunner.RunAsync(query.QueryText, query.ToNeo4jDriverParameters(gc));
+        }
+
         // public static IStatementResult Run(this ITransaction transaction, CypherQuery query, IGraphClient gc)
         // {
         //     return transaction.Run(query.QueryText, query.ToNeo4jDriverParameters(gc));

--- a/Neo4jClient/OperationCompletedEventHandler.cs
+++ b/Neo4jClient/OperationCompletedEventHandler.cs
@@ -12,7 +12,9 @@ namespace Neo4jClient
     {
         public string Database { get; set; }
         public string Identifier { get; set; }
+        [Obsolete("Replaced with 'LastBookmarks' will be removed in the next version.")]
         public Bookmark LastBookmark { get; set; }
+        public Bookmarks LastBookmarks { get; set; }
         public string QueryText { get; set; }
         public int ResourcesReturned { get; set; }
         public TimeSpan TimeTaken { get; set; }
@@ -20,6 +22,7 @@ namespace Neo4jClient
         public bool HasException => Exception != null;
         public int? MaxExecutionTime { get; set; }
         public NameValueCollection CustomHeaders { get; set; }
+
         public IEnumerable<Bookmark> BookmarksUsed { get; set; }
         public QueryStats QueryStats { get; set; }
 

--- a/Neo4jClient/StatementResultHelper.cs
+++ b/Neo4jClient/StatementResultHelper.cs
@@ -530,7 +530,12 @@ namespace Neo4jClient
             public object this[string key] => properties[key];
 
             public IReadOnlyDictionary<string, object> Properties => new ReadOnlyDictionary<string, object>(properties);
+            
+            [Obsolete ("Long versions of the ID will be removed in the future, use ElementId instead")]
             public long Id => int.MinValue;
+
+            /// <inheritdoc />
+            public string ElementId { get; set; }
 
 
             public IReadOnlyList<string> Labels => new List<string>();
@@ -539,7 +544,7 @@ namespace Neo4jClient
 
             protected bool Equals(Neo4jClientNode other)
             {
-                return Equals(properties, other.properties);
+                return Equals(properties, other.properties) && Equals(ElementId, other.ElementId);
             }
 
             public bool Equals(INode other)


### PR DESCRIPTION
I've noticed that the desire to use native datetime instances is growing specially with issue #332 that, although `Neo4jDateTimeAttribute` exists it does not support a comparison with a parameter that is not added through `.WithParam()`. Therefore I took suggestion there to create a "global" (client instance) setting that switches such behavior.

In fact, my PR #275 wished to address this as well (I will continue with this PR as I intend to have a direct serializer instead of still going through creating an intermediate JSON representation).