### PR TITLE
Issue 458 WithParam: throw exception if parameter starts with '$' (or…

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
@@ -61,14 +61,14 @@ namespace Neo4jClient.Tests.Cypher
             var ex = Assert.Throws<ArgumentException>(
                 () => query.WithParam("foo", 456)
             );
-            Assert.Equal("foo", ex.ParamName);
-            Assert.Equal("A parameter with the given key is already defined in the query." + Environment.NewLine + "Parameter name: foo", ex.Message);
+            Assert.Equal("key", ex.ParamName);
+            Assert.Equal("A parameter with the given key 'foo' is already defined in the query." + Environment.NewLine + "Parameter name: key", ex.Message);
 
             ex = Assert.Throws<ArgumentException>(
                 () => query.WithParams( new { foo = 456})
             );
-            Assert.Equal("foo", ex.ParamName);
-            Assert.Equal("A parameter with the given key is already defined in the query." + Environment.NewLine + "Parameter name: foo", ex.Message);
+            Assert.Equal("parameters", ex.ParamName);
+            Assert.Equal("A parameter with the given key 'foo' is already defined in the query." + Environment.NewLine + "Parameter name: parameters", ex.Message);
 
         }
 
@@ -85,8 +85,8 @@ namespace Neo4jClient.Tests.Cypher
             var ex = Assert.Throws<ArgumentException>(
                 () => query.WithParam("p0", 456)
             );
-            Assert.Equal("p0", ex.ParamName);
-            Assert.Equal("A parameter with the given key is already defined in the query." + Environment.NewLine + "Parameter name: p0", ex.Message);
+            Assert.Equal("key", ex.ParamName);
+            Assert.Equal("A parameter with the given key 'p0' is already defined in the query." + Environment.NewLine + "Parameter name: key", ex.Message);
         }
 
         [Fact]
@@ -99,15 +99,15 @@ namespace Neo4jClient.Tests.Cypher
             // Assert WithParam
             var ex = Assert.Throws<ArgumentException>(() => new CypherFluentQuery(client).WithParam("$uuid", ""));
             ex.Should().NotBeNull();
-            ex.Message.Should().Be("Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: $uuid");
+            ex.Message.Should().Be("The parameter with the given key '$uuid' is not valid. Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: key");
 
             ex = Assert.Throws<ArgumentException>(() => new CypherFluentQuery(client).WithParam("0uuid", ""));
             ex.Should().NotBeNull();
-            ex.Message.Should().Be("Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: 0uuid");
+            ex.Message.Should().Be("The parameter with the given key '0uuid' is not valid. Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: key");
 
             ex = Assert.Throws<ArgumentException>(() => new CypherFluentQuery(client).WithParam("{uuid}", ""));
             ex.Should().NotBeNull();
-            ex.Message.Should().Be("Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: {uuid}");
+            ex.Message.Should().Be("The parameter with the given key '{uuid}' is not valid. Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.\r\nParameter name: key");
 
             // no exception for correct usage
             var ex2 = Record.Exception(() => new CypherFluentQuery(client).WithParam("uuid", ""));

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
@@ -66,7 +66,7 @@ namespace Neo4jClient.Tests.Cypher
             Assert.Equal("A parameter with the given key 'foo' is already defined in the query." + Environment.NewLine + "Parameter name: key", ex.Message);
 
             ex = Assert.Throws<ArgumentException>(
-                () => query.WithParams( new { foo = 456})
+                () => query.WithParams( new { foo = 456 })
             );
             Assert.Equal("parameters", ex.ParamName);
             Assert.Equal("A parameter with the given key 'foo' is already defined in the query." + Environment.NewLine + "Parameter name: parameters", ex.Message);

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
@@ -63,6 +63,13 @@ namespace Neo4jClient.Tests.Cypher
             );
             Assert.Equal("foo", ex.ParamName);
             Assert.Equal("A parameter with the given key is already defined in the query." + Environment.NewLine + "Parameter name: foo", ex.Message);
+
+            ex = Assert.Throws<ArgumentException>(
+                () => query.WithParams( new { foo = 456})
+            );
+            Assert.Equal("foo", ex.ParamName);
+            Assert.Equal("A parameter with the given key is already defined in the query." + Environment.NewLine + "Parameter name: foo", ex.Message);
+
         }
 
         [Fact]

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithParamTests.cs
@@ -55,7 +55,8 @@ namespace Neo4jClient.Tests.Cypher
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
                 .Match("n")
-                .WithParam("foo", 123);
+                .WithParam("foo", 123)
+                .WithParam("bar", 123);
 
             // Assert
             var ex = Assert.Throws<ArgumentException>(
@@ -70,6 +71,11 @@ namespace Neo4jClient.Tests.Cypher
             Assert.Equal("parameters", ex.ParamName);
             Assert.Equal("A parameter with the given key 'foo' is already defined in the query." + Environment.NewLine + "Parameter name: parameters", ex.Message);
 
+            ex = Assert.Throws<ArgumentException>(
+                () => query.WithParams(new { foo = 456, bar = 456 })
+            );
+            Assert.Equal("parameters", ex.ParamName);
+            Assert.Equal("Parameters with the given keys 'foo, bar' are already defined in the query." + Environment.NewLine + "Parameter name: parameters", ex.Message);
         }
 
         [Fact]

--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -149,10 +149,11 @@ namespace Neo4jClient.Cypher
         public ICypherFluentQuery WithParam(string key, object value)
         {
             if (string.IsNullOrWhiteSpace(key) || char.IsDigit(key[0]) || char.IsSymbol(key[0]) || key[0] == '{')
-                throw new ArgumentException("Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.", key);
+                throw new ArgumentException($"The parameter with the given key '{key}' is not valid. Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.", nameof(key));
 
             if (QueryWriter.ContainsParameterWithKey(key))
-                throw new ArgumentException("A parameter with the given key is already defined in the query.", key);
+                throw new ArgumentException($"A parameter with the given key '{key}' is already defined in the query.", nameof(key));
+
             return Mutate(w => w.CreateParameter(key, value));
         }
 
@@ -161,10 +162,10 @@ namespace Neo4jClient.Cypher
             if (parameters == null || parameters.Count == 0) return this;
 
             if (parameters.Keys.Any(key => string.IsNullOrWhiteSpace(key) || char.IsDigit(key[0]) || char.IsSymbol(key[0]) || key[0] == '{'))
-                throw new ArgumentException("Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.", parameters.Keys.First(key => string.IsNullOrWhiteSpace(key) || char.IsDigit(key[0]) || char.IsSymbol(key[0])));
+                throw new ArgumentException($"The parameter with the given key '{parameters.Keys.First(key => string.IsNullOrWhiteSpace(key) || char.IsDigit(key[0]) || char.IsSymbol(key[0]))}' is not valid. Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.", nameof(parameters));
 
             if (parameters.Keys.Any(key => QueryWriter.ContainsParameterWithKey(key)))
-                throw new ArgumentException("A parameter with the given key is already defined in the query.", parameters.Keys.First(key => QueryWriter.ContainsParameterWithKey(key)));
+                throw new ArgumentException($"A parameter with the given key '{parameters.Keys.First(key => QueryWriter.ContainsParameterWithKey(key))}' is already defined in the query.", nameof(parameters));
 
             return Mutate(w => w.CreateParameters(parameters));
         }


### PR DESCRIPTION
… any other not allowed character).

Issue 458 WithParam: throw exception if parameter starts with '$' (or any other not allowed character). 

Issue 459 WithParam: exeption when using already existing param name outputs "key" instead of param name