### PR TITLE
Adds `.Show` to the interface and fixes Cypher Capabilities

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryDatabaseAdministrationTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryDatabaseAdministrationTests.cs
@@ -371,11 +371,20 @@ namespace Neo4jClient.Tests.Cypher
             public void ThrowsInvalidOperationException_IfNotOnASupportedVersion()
             {
                 var client = Substitute.For<IRawGraphClient>();
-                client.CypherCapabilities.Returns(new CypherCapabilities { SupportsMultipleTenancy = false });
+                client.CypherCapabilities.Returns(CypherCapabilities.Cypher30);
 
                 var ex = Assert.Throws<InvalidOperationException>(() => new CypherFluentQuery(client).Show("DATABASES"));
                 ex.Should().NotBeNull();
                 ex.Message.Should().Be("SHOW commands are not supported in Neo4j versions older than 4.0");
+            }
+
+            [Fact]
+            public void ShowIsAccessibleViaTheICypherFluentQueryInterface()
+            {
+                ICypherFluentQuery query = new CypherFluentQuery(MockClient);
+                query = query.Show("DATABASES");
+
+                query.Query.QueryText.Should().Be("SHOW DATABASES");
             }
 
             [Theory]

--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -15,6 +15,7 @@ namespace Neo4jClient.Cypher
             SupportsHasFunction = cypherCapabilities.SupportsHasFunction;
             SupportsMultipleTenancy = cypherCapabilities.SupportsMultipleTenancy;
             SupportsStoredProceduresWithTransactionalBatching = cypherCapabilities.SupportsStoredProceduresWithTransactionalBatching;
+            SupportsShow = cypherCapabilities.SupportsShow;
         }
 
         public static readonly CypherCapabilities Cypher19 = new CypherCapabilities
@@ -36,6 +37,7 @@ namespace Neo4jClient.Cypher
         public static readonly CypherCapabilities Cypher30 = new CypherCapabilities(Cypher23) { SupportsStoredProcedures = true, SupportsHasFunction = false };
         public static readonly CypherCapabilities Cypher40 = new CypherCapabilities(Cypher30) { SupportsMultipleTenancy = true, SupportsShow = true };
         public static readonly CypherCapabilities Cypher44 = new CypherCapabilities(Cypher40) { SupportsStoredProceduresWithTransactionalBatching = true };
+        
         public static readonly CypherCapabilities Default = Cypher20;
         
         /// <summary>

--- a/Neo4jClient/Cypher/ICypherFluentQuery`DatabaseAdministration.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery`DatabaseAdministration.cs
@@ -77,6 +77,15 @@ namespace Neo4jClient.Cypher
         /// <exception cref="InvalidOperationException">Thrown if this is called against a server version without multiple tenancy.</exception>
         /// <exception cref="ArgumentException">Thrown if the <paramref name="databaseName"/> given is <c>null</c> or whitespace.</exception>
         ICypherFluentQuery StopDatabase(string databaseName);
+        
+        /// <summary>
+        ///     Executes <c>SHOW</c> against the database, passing in the <paramref name="command"/>. <see cref="Yield"/> should be used after to get the results.
+        /// </summary>
+        /// <param name="command">The command to call <c>SHOW</c> with.</param>
+        /// <returns>An <see cref="ICypherFluentQuery" /> instance to continue the query with.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if this is called against a server version that doesn't support <c>SHOW</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="command"/> given is <c>null</c> or whitespace.</exception>
+        ICypherFluentQuery Show(string command);
     }
 
 }


### PR DESCRIPTION
Fixes #462 

`.Show()` is now in the `ICypherFluentInterface`

To use it would be something like:

```
var names = await client. Cypher
    .Show("DATABASES")
    .Yield("name")
    .Return(name => name.As<string>()).ResultsAsync;
```

