### PR TITLE
Added Cypher50 capabilities for Neo4j5 null comparison

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherWhereExpressionBuilderTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherWhereExpressionBuilderTests.cs
@@ -174,6 +174,36 @@ namespace Neo4jClient.Tests.Cypher
         }
 
         [Fact]
+        public void For50VersionsEvaluateTrueWhenComparingMissingNullablePropertyToNotNullProperty()
+        {
+            var parameters = new Dictionary<string, object>();
+            var fooWithNulls = new Foo
+            {
+                NullableBar = null
+            };
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != fooWithNulls.NullableBar;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher50);
+
+            Assert.Equal("(foo.NullableBar is not null)", result);
+        }
+
+        [Fact]
+        public void For50VersionsEvaluateTrueWhenComparingMissingNullablePropertyToNullProperty()
+        {
+            var parameters = new Dictionary<string, object>();
+            var fooWithNulls = new Foo
+            {
+                NullableBar = null
+            };
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == fooWithNulls.NullableBar;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher50);
+
+            Assert.Equal("(foo.NullableBar is null)", result);
+        }
+
+        [Fact]
         public void For30VersionsEvaluateTrueWhenComparingMissingNullablePropertyToNullProperty()
         {
             var parameters = new Dictionary<string, object>();

--- a/Neo4jClient/BoltGraphClient.cs
+++ b/Neo4jClient/BoltGraphClient.cs
@@ -301,6 +301,8 @@ namespace Neo4jClient
                     CypherCapabilities = CypherCapabilities.Cypher40;
                 if(ServerVersion >= new Version(4,4))
                     CypherCapabilities = CypherCapabilities.Cypher44;
+                if (ServerVersion >= new Version(5, 0))
+                    CypherCapabilities = CypherCapabilities.Cypher50;
             }
 
             await session.CloseAsync().ConfigureAwait(false);

--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -38,7 +38,8 @@ namespace Neo4jClient.Cypher
         public static readonly CypherCapabilities Cypher35 = new CypherCapabilities(Cypher30) { SupportsRuntime = true };
         public static readonly CypherCapabilities Cypher40 = new CypherCapabilities(Cypher35) { SupportsMultipleTenancy = true, SupportsShow = true };
         public static readonly CypherCapabilities Cypher44 = new CypherCapabilities(Cypher40) { SupportsStoredProceduresWithTransactionalBatching = true };
-       
+        public static readonly CypherCapabilities Cypher50 = new CypherCapabilities(Cypher44) { SupportsNullComparisonsWithIsOperator = true };
+
         public static readonly CypherCapabilities Default = Cypher20;
         
         /// <summary>


### PR DESCRIPTION
Neo4j 4.4 deprecated EXISTS(), but Neo4j 5 completely removed it. 

I added `Cypher50` capabilities by turning on the `SupportsNullComparisonsWithIsOperator` capability.