### PR TITLE
Also set `SupportsRuntime `

### DIFF
--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -16,6 +16,7 @@ namespace Neo4jClient.Cypher
             SupportsMultipleTenancy = cypherCapabilities.SupportsMultipleTenancy;
             SupportsStoredProceduresWithTransactionalBatching = cypherCapabilities.SupportsStoredProceduresWithTransactionalBatching;
             SupportsShow = cypherCapabilities.SupportsShow;
+            SupportsRuntime = cypherCapabilities.SupportsRuntime;
         }
 
         public static readonly CypherCapabilities Cypher19 = new CypherCapabilities
@@ -41,7 +42,7 @@ namespace Neo4jClient.Cypher
         public static readonly CypherCapabilities Cypher50 = new CypherCapabilities(Cypher44) { SupportsNullComparisonsWithIsOperator = true };
 
         public static readonly CypherCapabilities Default = Cypher20;
-        
+
         /// <summary>
         /// Neo4j 4.0 provides support for multiple tenancy, which means commands like CREATE DATABASE etc
         /// </summary>
@@ -52,7 +53,7 @@ namespace Neo4jClient.Cypher
         public bool SupportsNullComparisonsWithIsOperator { get; set; }
         public bool SupportsStartsWith { get; set; }
         public bool SupportsStoredProceduresWithTransactionalBatching { get; set; }
-        
+
         /// <summary>
         /// Runtime is available to be set in 3.5 onwards.
         /// </summary>
@@ -70,6 +71,6 @@ namespace Neo4jClient.Cypher
         /// </summary>
         public bool SupportsHasFunction { get; set; }
 
-        
+
     }
 }


### PR DESCRIPTION
The `SupportsRuntime` was not set in most static `CypherCapabilities` instances. This causes `boltClient.Cypher.Runtime(CypherRuntime.Parallel)` to throw an exception:

```
System.InvalidOperationException: 'runtime=' not supported in Neo4j versions older than 3.5
   at Neo4jClient.Cypher.CypherFluentQuery.Runtime(String runtime)
   at Neo4jClient.Cypher.CypherFluentQuery.Runtime(CypherRuntime runtime)
   ...
```

For now, we fixed it in our own code by just setting the `CypherCapabilities.SupportsRuntime` before using the `Runtime(...)`:

```cs
/// <inheritdoc />
public async Task<ICypherFluentQuery> FluentReadQuery()
{
  var boltClient = await this.ConnectedBoltGraphClient();

  boltClient.CypherCapabilities.SupportsRuntime = true; // <--- the temporary fix

  var cypherFluentQuery = _neo4JConnectionProvider.GetConfiguration().UseParallelQueries
    ? boltClient.Cypher.Runtime(CypherRuntime.Parallel).Read // <--- without the fix above, this throws an exception
    : boltClient.Cypher.Read;

  return cypherFluentQuery;
}

```